### PR TITLE
Added property and custom validation attribute check

### DIFF
--- a/DevTrends.WCFDataAnnotations.UnitTests/DataAnnotationsObjectValidatorTests.cs
+++ b/DevTrends.WCFDataAnnotations.UnitTests/DataAnnotationsObjectValidatorTests.cs
@@ -3,63 +3,56 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using NUnit.Framework;
 
-namespace DevTrends.WCFDataAnnotations.UnitTests
-{
-    [TestFixture]
-    public class DataAnnotationsObjectValidatorTests
-    {
-        private const string RequiredErrorMessage = "{0} is required";
-        private const string RegexErrorMessage = "{0} can only contains numbers";
-        private const string RangeErrorMessage = "{0} must be between {1} and {2}";
+namespace DevTrends.WCFDataAnnotations.UnitTests {
+  [TestFixture]
+  [Category(nameof(DataAnnotationsObjectValidatorTests))]
+  public class DataAnnotationsObjectValidatorTests {
+    private const string RequiredErrorMessage = "{0} is required";
+    private const string RegexErrorMessage = "{0} can only contains numbers";
+    private const string RangeErrorMessage = "{0} must be between {1} and {2}";
 
-        private DataAnnotationsObjectValidator _validator;
+    private DataAnnotationsObjectValidator _validator;
 
-        [SetUp]
-        public void Setup()
-        {
-            _validator = new DataAnnotationsObjectValidator();
-        }
+    [SetUp]
+    public void Setup() {
+      _validator = new DataAnnotationsObjectValidator();
+    }
 
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Passed_Object_With_No_DataAnnotations()
-        {
-            var result = _validator.Validate("blah");
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Passed_Object_With_No_DataAnnotations() {
+      var result = _validator.Validate("blah");
 
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);
-        }
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
 
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Passed_Null()
-        {
-            var result = _validator.Validate(null);
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Passed_Null() {
+      var result = _validator.Validate(null);
 
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);
-        }        
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
 
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_Object_Contains_Collection_With_Invalid_Properties()
-        {
-            var result = _validator.Validate(new List<TestClass>
-            {
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Object_Contains_Collection_With_Invalid_Properties() {
+      var result = _validator.Validate(new List<TestClass>
+      {
                 new TestClass { Property1 = null, Property2 = "test" },
                 new TestClass { Property1 = null, Property2 = "12345" },
                 new TestClass { Property1 = "required", Property2 = "test" }
             });
 
-            Assert.That(result.Count(), Is.EqualTo(4));
-        }
+      Assert.That(result.Count(), Is.EqualTo(4));
+    }
 
-        [Test]
-        public void
-            Validate_Returns_ValidationResult_When_Passed_Object_Contains_Nested_Collections_With_Invalid_Properties()
-        {
-            var result = _validator.Validate(new TestClass3
-            {
-                Properties1 = null,
-                Properties2 = new List<List<TestClass>>()
-                {
+    [Test]
+    public void
+        Validate_Returns_ValidationResult_When_Passed_Object_Contains_Nested_Collections_With_Invalid_Properties() {
+      var result = _validator.Validate(new TestClass3 {
+        Properties1 = null,
+        Properties2 = new List<List<TestClass>>()
+          {
                     new List<TestClass>
                     {
                         new TestClass
@@ -97,83 +90,139 @@ namespace DevTrends.WCFDataAnnotations.UnitTests
                         },
                     }
                 },
-                Property3 = null
-            }).ToList();
+        Property3 = null
+      }).ToList();
 
-            Assert.That(result.Count, Is.EqualTo(6));
+      Assert.That(result.Count, Is.EqualTo(6));
 
-            Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Properties1")));
-            Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
-            Assert.That(result[2].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
-            Assert.That(result[3].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
-            Assert.That(result[4].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
-            Assert.That(result[5].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property3")));
-        }
-
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_Invalid_Sub_Properties()
-        {
-            var result =
-                _validator.Validate(new TestClass
-                {
-                    Property1 = "test",
-                    Property2 = "12345",
-                    Property3 = new TestClass2 { Property3 = null, Property4 = 20 }
-                }).ToList();
-
-            Assert.That(result.Count, Is.EqualTo(2));
-            Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property3")));
-            Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RangeErrorMessage, "Property4", 1, 10)));
-        }
-
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_One_Invalid_Property()
-        {
-            var result = _validator.Validate(new TestClass { Property1 = null, Property2 = "12345" });
-
-            Assert.That(result.Count(), Is.EqualTo(1));
-            Assert.That(result.First().ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
-        }
-
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_Two_Invalid_Properties()
-        {
-            var result = _validator.Validate(new TestClass { Property1 = null, Property2 = "test" }).ToList();
-
-            Assert.That(result.Count, Is.EqualTo(2));
-            Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
-            Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
-        }
-
-        private class TestClass
-        {
-            [Required(ErrorMessage = RequiredErrorMessage)]
-            public string Property1 { get; set; }
-
-            [RegularExpression(@"\d{1,10}", ErrorMessage = RegexErrorMessage)]
-            public string Property2 { get; set; }
-
-            public TestClass2 Property3 { get; set; }
-        }
-
-        private class TestClass2
-        {
-            [Required(ErrorMessage = RequiredErrorMessage)]
-            public string Property3 { get; set; }
-
-            [System.ComponentModel.DataAnnotations.Range(1, 10, ErrorMessage = RangeErrorMessage)]
-            public int Property4 { get; set; }
-        }
-
-        private class TestClass3
-        {
-            [Required(ErrorMessage = RequiredErrorMessage)]
-            public IList<TestClass> Properties1 { get; set; }
-
-            public IEnumerable<IEnumerable<TestClass>> Properties2 { get; set; }
-
-            [Required(ErrorMessage = RequiredErrorMessage)]
-            public TestClass2 Property3 { get; set; }
-        }
+      Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Properties1")));
+      Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
+      Assert.That(result[2].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
+      Assert.That(result[3].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
+      Assert.That(result[4].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
+      Assert.That(result[5].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property3")));
     }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_Invalid_Sub_Properties() {
+      var result =
+          _validator.Validate(new TestClass {
+            Property1 = "test",
+            Property2 = "12345",
+            Property3 = new TestClass2 { Property3 = null, Property4 = 20 }
+          }).ToList();
+
+      Assert.That(result.Count, Is.EqualTo(2));
+      Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property3")));
+      Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RangeErrorMessage, "Property4", 1, 10)));
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_One_Invalid_Property() {
+      var result = _validator.Validate(new TestClass { Property1 = null, Property2 = "12345" });
+
+      Assert.That(result.Count(), Is.EqualTo(1));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Object_That_Has_Two_Invalid_Properties() {
+      var result = _validator.Validate(new TestClass { Property1 = null, Property2 = "test" }).ToList();
+
+      Assert.That(result.Count, Is.EqualTo(2));
+      Assert.That(result[0].ErrorMessage, Is.StringContaining(string.Format(RequiredErrorMessage, "Property1")));
+      Assert.That(result[1].ErrorMessage, Is.StringContaining(string.Format(RegexErrorMessage, "Property2")));
+    }
+
+
+    [Test]
+    public void Validate_Custom_Validation_Attributes_Returns_ValidationResult_When_Passed_Object_Is_Invalid() {
+      var result = _validator.Validate(new TestClass_With_Custom_Validation_attribute() );
+      
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(1));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining("ERROR ERROR"));
+    }
+
+    [Test]
+    public void Validate_Enumerables_Returns_ValidationResult_When_Passed_IValidatableObject_That_Is_Not_Valid() {
+      var testObject = new TestClass3 {
+        Properties1 = new List<TestClass> {
+          new TestClass { Property2 = "abz"}
+        },
+        Property3 = new TestClass2()
+      };
+
+      var result = _validator.Validate(testObject);
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Validate_Nested_Enumerables_Returns_ValidationResult_When_Passed_IValidatableObject_That_Is_Not_Valid() {
+      var testObject = new TestClass3 {
+        Properties1 = new List<TestClass> {
+          new TestClass { Property2 = "abz"}
+        },
+        Properties2 = new IEnumerable<TestClass>[] {
+          new List<TestClass> {
+            new TestClass(),
+            new TestClass()
+          },
+        },
+        Property3 = new TestClass2()
+      };
+
+      var result = _validator.Validate(testObject);
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(6));
+    }
+
+    private class TestClass {
+      [Required(ErrorMessage = RequiredErrorMessage)]
+      public string Property1 { get; set; }
+
+      [RegularExpression(@"\d{1,10}", ErrorMessage = RegexErrorMessage)]
+      public string Property2 { get; set; }
+
+      public TestClass2 Property3 { get; set; }
+    }
+
+    private class TestClass2 {
+      [Required(ErrorMessage = RequiredErrorMessage)]
+      public string Property3 { get; set; }
+
+      [System.ComponentModel.DataAnnotations.Range(1, 10, ErrorMessage = RangeErrorMessage)]
+      public int Property4 { get; set; }
+    }
+
+    private class TestClass3 {
+      [Required(ErrorMessage = RequiredErrorMessage)]
+      public IList<TestClass> Properties1 { get; set; }
+
+      public IEnumerable<IEnumerable<TestClass>> Properties2 { get; set; }
+
+      [Required(ErrorMessage = RequiredErrorMessage)]
+      public TestClass2 Property3 { get; set; }
+    }
+
+    private class TestClass_With_Custom_Validation_attribute {
+      [CustomRequiredValidator]
+      public string SomeText { get; set; }
+    }
+
+    private class CustomRequiredValidator : ValidationAttribute {
+      public override bool IsValid(object value) {
+        return value != null;
+      }
+
+      protected override ValidationResult IsValid(object value, ValidationContext validationContext) {
+        return value != null ?
+          ValidationResult.Success :
+          new ValidationResult("ERROR ERROR");
+      }
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations.UnitTests/ErrorMessageGeneratorTests.cs
+++ b/DevTrends.WCFDataAnnotations.UnitTests/ErrorMessageGeneratorTests.cs
@@ -3,67 +3,59 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using NUnit.Framework;
 
-namespace DevTrends.WCFDataAnnotations.UnitTests
-{
-    [TestFixture]
-    public class ErrorMessageGeneratorTests
-    {
-        private const string OperationName = "DoSomething";
+namespace DevTrends.WCFDataAnnotations.UnitTests {
+  [TestFixture]
+  [Category(nameof(ErrorMessageGeneratorTests))]
+  public class ErrorMessageGeneratorTests {
+    private const string OperationName = "DoSomething";
 
-        private ErrorMessageGenerator _errorMessageGenerator;
+    private ErrorMessageGenerator _errorMessageGenerator;
 
-        [SetUp]
-        public void Setup()
-        {
-            _errorMessageGenerator = new ErrorMessageGenerator();
-        }
-
-        [Test]
-        public void GenerateErrorMessage_Must_Be_Supplied_With_OperationName()
-        {
-            Assert.Throws<ArgumentNullException>(() => _errorMessageGenerator.GenerateErrorMessage(null, new[] { new ValidationResult("test") }));
-        }
-
-        [Test]
-        public void GenerateErrorMessage_Must_Be_Supplied_With_ValidationResults()
-        {
-            Assert.Throws<ArgumentNullException>(() => _errorMessageGenerator.GenerateErrorMessage(OperationName, null));
-        }
-
-        [Test]
-        public void GenerateErrorMessage_ValidationResults_Cannot_Be_Empty()
-        {
-            Assert.Throws<ArgumentException>(() => _errorMessageGenerator.GenerateErrorMessage(OperationName, Enumerable.Empty<ValidationResult>()));
-        }
-
-        [Test]
-        public void GenerateErrorMessage_Result_Contains_OperationName()
-        {
-            var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { new ValidationResult("test") });
-
-            Assert.That(result, Is.StringContaining(OperationName));
-        }
-
-        [Test]
-        public void GenerateErrorMessage_Result_Contains_ValidationResult_ErrorMessage_When_Single_ValidationResult()
-        {
-            var validationResult = new ValidationResult("oops error");
-
-            var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { validationResult });
-
-            Assert.That(result, Is.StringContaining(validationResult.ErrorMessage));
-        }
-
-        [Test]
-        public void GenerateErrorMessage_Result_Contains_ValidationResults_ErrorMessages_When_Multiple_ValidationResults()
-        {
-            var validationResult = new ValidationResult("oops error");
-            var validationResult2 = new ValidationResult("another problem");
-
-            var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { validationResult, validationResult2 });
-
-            Assert.That(result, Is.StringContaining(validationResult.ErrorMessage));
-            Assert.That(result, Is.StringContaining(validationResult2.ErrorMessage));
-        }
+    [SetUp]
+    public void Setup() {
+      _errorMessageGenerator = new ErrorMessageGenerator();
     }
+
+    [Test]
+    public void GenerateErrorMessage_Must_Be_Supplied_With_OperationName() {
+      Assert.Throws<ArgumentNullException>(() => _errorMessageGenerator.GenerateErrorMessage(null, new[] { new ValidationResult("test") }));
+    }
+
+    [Test]
+    public void GenerateErrorMessage_Must_Be_Supplied_With_ValidationResults() {
+      Assert.Throws<ArgumentNullException>(() => _errorMessageGenerator.GenerateErrorMessage(OperationName, null));
+    }
+
+    [Test]
+    public void GenerateErrorMessage_ValidationResults_Cannot_Be_Empty() {
+      Assert.Throws<ArgumentException>(() => _errorMessageGenerator.GenerateErrorMessage(OperationName, Enumerable.Empty<ValidationResult>()));
+    }
+
+    [Test]
+    public void GenerateErrorMessage_Result_Contains_OperationName() {
+      var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { new ValidationResult("test") });
+
+      Assert.That(result, Is.StringContaining(OperationName));
+    }
+
+    [Test]
+    public void GenerateErrorMessage_Result_Contains_ValidationResult_ErrorMessage_When_Single_ValidationResult() {
+      var validationResult = new ValidationResult("oops error");
+
+      var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { validationResult });
+
+      Assert.That(result, Is.StringContaining(validationResult.ErrorMessage));
+    }
+
+    [Test]
+    public void GenerateErrorMessage_Result_Contains_ValidationResults_ErrorMessages_When_Multiple_ValidationResults() {
+      var validationResult = new ValidationResult("oops error");
+      var validationResult2 = new ValidationResult("another problem");
+
+      var result = _errorMessageGenerator.GenerateErrorMessage(OperationName, new[] { validationResult, validationResult2 });
+
+      Assert.That(result, Is.StringContaining(validationResult.ErrorMessage));
+      Assert.That(result, Is.StringContaining(validationResult2.ErrorMessage));
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations.UnitTests/NullCheckObjectValidatorTests.cs
+++ b/DevTrends.WCFDataAnnotations.UnitTests/NullCheckObjectValidatorTests.cs
@@ -1,35 +1,31 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 
-namespace DevTrends.WCFDataAnnotations.UnitTests
-{
-    [TestFixture]
-    public class NullCheckObjectValidatorTests
-    {
-        private NullCheckObjectValidator _validator;
+namespace DevTrends.WCFDataAnnotations.UnitTests {
+  [TestFixture]
+  [Category(nameof(NullCheckObjectValidatorTests))]
+  public class NullCheckObjectValidatorTests {
+    private NullCheckObjectValidator _validator;
 
-        [SetUp]
-        public void Setup()
-        {
-            _validator = new NullCheckObjectValidator();
-        }        
-
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_Null()
-        {
-            var result = _validator.Validate(null);
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(1));
-        }
-
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Not_Passed_Null()
-        {
-            var result = _validator.Validate("not null");
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);            
-        }
+    [SetUp]
+    public void Setup() {
+      _validator = new NullCheckObjectValidator();
     }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Null() {
+      var result = _validator.Validate(null);
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Not_Passed_Null() {
+      var result = _validator.Validate("not null");
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations.UnitTests/ValidatableObjectValidatorTests.cs
+++ b/DevTrends.WCFDataAnnotations.UnitTests/ValidatableObjectValidatorTests.cs
@@ -3,71 +3,127 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using NUnit.Framework;
 
-namespace DevTrends.WCFDataAnnotations.UnitTests
-{
-    [TestFixture]
-    public class ValidatableObjectValidatorTests
-    {
-        private const string ErrorMessage = "oops message";
-        private ValidatableObjectValidator _validator;
+namespace DevTrends.WCFDataAnnotations.UnitTests {
+  [TestFixture]
+  [Category(nameof(ValidatableObjectValidatorTests))]
+  public class ValidatableObjectValidatorTests {
+    private const string ErrorMessage = "oops message";
+    private ValidatableObjectValidator _validator;
 
-        [SetUp]
-        public void Setup()
-        {
-            _validator = new ValidatableObjectValidator();
-        }
-
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Passed_Null()
-        {
-            var result = _validator.Validate(null);
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);
-        }
-
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Not_Passed_IValidatableObject()
-        {
-            var result = _validator.Validate("blah");
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);
-        }
-
-        [Test]
-        public void Validate_Does_Not_Return_ValidationResult_When_Passed_IValidatableObject_That_Is_Valid()
-        {
-            var result = _validator.Validate(new ValidValidatableObject());
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Any(), Is.False);
-        }
-
-        [Test]
-        public void Validate_Returns_ValidationResult_When_Passed_IValidatableObject_That_Is_Not_Valid()
-        {
-            var result = _validator.Validate(new InvalidValidatableObject());
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(1));
-            Assert.That(result.First().ErrorMessage, Is.StringContaining(ErrorMessage));
-        }
-
-        private class ValidValidatableObject : IValidatableObject
-        {
-            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-            {
-                return Enumerable.Empty<ValidationResult>();
-            }
-        }
-
-        private class InvalidValidatableObject : IValidatableObject
-        {
-            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-            {
-                yield return new ValidationResult(ErrorMessage);
-            }
-        }
+    [SetUp]
+    public void Setup() {
+      _validator = new ValidatableObjectValidator();
     }
+
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Passed_Null() {
+      var result = _validator.Validate(null);
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
+
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Not_Passed_IValidatableObject() {
+      var result = _validator.Validate("blah");
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
+
+    [Test]
+    public void Validate_Does_Not_Return_ValidationResult_When_Passed_IValidatableObject_That_Is_Valid() {
+      var result = _validator.Validate(new ValidValidatableObject());
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Any(), Is.False);
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_IValidatableObject_That_Is_Not_Valid() {
+      var result = _validator.Validate(new InvalidValidatableObject());
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(1));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining(ErrorMessage));
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Nested_IValidatableObject_That_Is_Not_Valid() {
+      var result = _validator.Validate(new ValidatableObjectNested { InvalidValidatableObject = new InvalidValidatableObject() });
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(1));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining(ErrorMessage));
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Enumerable_IValidatableObject_That_Is_Not_Valid() {
+      var result = _validator.Validate(new ValidatableObjectEnumerable { InvalidValidatableObjectList = new List<InvalidValidatableObject> { new InvalidValidatableObject(), new InvalidValidatableObject() }});
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(2));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining(ErrorMessage));
+    }
+
+    [Test]
+    public void Validate_Returns_ValidationResult_When_Passed_Nested_Enumerable_IValidatableObject_That_Is_Not_Valid() {
+      var result = _validator.Validate(new ValidatableObjectNestedEnumerable {
+        ValidatableObjectSubEnumerableList = new List<ValidatableObjectNestedSubEnumerable> {
+          new ValidatableObjectNestedSubEnumerable { InvalidValidatableObjectList = new List<InvalidValidatableObject> {
+            new InvalidValidatableObject(),
+            new InvalidValidatableObject()
+          }}
+        }
+      });
+
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.Count(), Is.EqualTo(2));
+      Assert.That(result.First().ErrorMessage, Is.StringContaining(ErrorMessage));
+    }
+
+    private class ValidValidatableObject : IValidatableObject {
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        return Enumerable.Empty<ValidationResult>();
+      }
+    }
+
+    private class InvalidValidatableObject : IValidatableObject {
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        yield return new ValidationResult(ErrorMessage);
+      }
+    }
+
+    private class ValidatableObjectNested : IValidatableObject {
+      public InvalidValidatableObject InvalidValidatableObject { get; set; }
+
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        return Enumerable.Empty<ValidationResult>();
+      }
+    }
+
+    private class ValidatableObjectEnumerable : IValidatableObject {
+      public List<InvalidValidatableObject> InvalidValidatableObjectList { get; set; }
+
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        return Enumerable.Empty<ValidationResult>();
+      }
+    }
+
+    private class ValidatableObjectNestedEnumerable : IValidatableObject {
+      public List<ValidatableObjectNestedSubEnumerable> ValidatableObjectSubEnumerableList { get; set; }
+
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        return Enumerable.Empty<ValidationResult>();
+      }
+    }
+
+    private class ValidatableObjectNestedSubEnumerable : IValidatableObject {
+      public List<InvalidValidatableObject> InvalidValidatableObjectList { get; set; }
+
+      public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+        return Enumerable.Empty<ValidationResult>();
+      }
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations.UnitTests/ValidatingParameterInspectorTests.cs
+++ b/DevTrends.WCFDataAnnotations.UnitTests/ValidatingParameterInspectorTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace DevTrends.WCFDataAnnotations.UnitTests {
   [TestFixture]
+  [Category(nameof(ValidatingParameterInspectorTests))]
   public class ValidatingParameterInspectorTests {
     private const string OperationName = "DoSomething";
 
@@ -119,7 +120,7 @@ namespace DevTrends.WCFDataAnnotations.UnitTests {
 
     [Test]
     public void BeforeCall_SkipNullCheck() {
-      var parameterInfo = new ParameterDetailsInfo {ParameterDetails = new List<ParameterDetails> { new ParameterDetails { Name = "test", Position = 0, SkipNullcheck = true }}};
+      var parameterInfo = new ParameterDetailsInfo { ParameterDetails = new List<ParameterDetails> { new ParameterDetails { Name = "test", Position = 0, SkipNullcheck = true } } };
       var inspector = new ValidatingParameterInspector(new[] { _singleValidatorMock.Object, _secondValidatorMock.Object, new NullCheckObjectValidator() }, _errorMessageGeneratorMock.Object, parameterInfo);
       object input = null;
       inspector.BeforeCall(OperationName, new[] { input });
@@ -164,7 +165,7 @@ namespace DevTrends.WCFDataAnnotations.UnitTests {
     public void BeforeCall_Throws_Exception_On_Null_When_No_SkipNullCheck_Defined() {
       var inspector = new ValidatingParameterInspector(new[] { _singleValidatorMock.Object, _secondValidatorMock.Object, new NullCheckObjectValidator() }, _errorMessageGeneratorMock.Object);
       object input = null;
-      
+
       Assert.Throws<FaultException>(
         () => inspector.BeforeCall(OperationName, new[] { input }));
     }

--- a/DevTrends.WCFDataAnnotations/DataAnnotationsObjectValidator.cs
+++ b/DevTrends.WCFDataAnnotations/DataAnnotationsObjectValidator.cs
@@ -4,100 +4,95 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  ///     Validates objects that have Data Annotation <see cref="ValidationAttribute" />
+  ///     derived types applied.
+  /// </summary>
+  public class DataAnnotationsObjectValidator : IObjectValidator {
     /// <summary>
-    ///     Validates objects that have Data Annotation <see cref="ValidationAttribute" />
-    ///     derived types applied.
+    ///     Validates the specified object.
     /// </summary>
-    public class DataAnnotationsObjectValidator : IObjectValidator
-    {
-        /// <summary>
-        ///     Validates the specified object.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        public IEnumerable<ValidationResult> Validate(object value)
-        {
-            if (value == null)
-            {
-                yield break;
-            }
+    /// <param name="value">The value.</param>
+    /// <returns></returns>
+    public IEnumerable<ValidationResult> Validate(object value) {
+      if (value == null) {
+        yield break;
+      }
 
-            foreach (var validationResult in GetValidationResults(value.GetType(), value))
-            {
-                yield return validationResult;
-            }
-        }
-
-        /// <summary>
-        ///     Validates the properties.
-        /// </summary>
-        /// <param name="propertyDescriptor">The property descriptor.</param>
-        /// <param name="container">The container.</param>
-        /// <returns></returns>
-        private IEnumerable<ValidationResult> ValidateProperties(PropertyDescriptor propertyDescriptor, object container)
-        {
-            var value = propertyDescriptor.GetValue(container);
-
-            var context = new ValidationContext(container, null, null)
-            {
-                DisplayName = propertyDescriptor.DisplayName,
-                MemberName = propertyDescriptor.Name
-            };
-
-            foreach (var validationAttibute in propertyDescriptor.Attributes.OfType<ValidationAttribute>())
-            {
-                var result = validationAttibute.GetValidationResult(value, context);
-
-                if (result != ValidationResult.Success)
-                {
-                    yield return result;
-                }
-            }
-
-            if (value != null)
-            {
-                foreach (var validationResult in GetValidationResults(propertyDescriptor.PropertyType, value))
-                {
-                    yield return validationResult;
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Gets the validation results.
-        /// </summary>
-        /// <param name="propertyType">Type of the property.</param>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        private IEnumerable<ValidationResult> GetValidationResults(Type propertyType, object value)
-        {
-            var enumerable = value as IEnumerable;
-
-            if (enumerable != null)
-            {
-                foreach (var item in enumerable)
-                {
-                    foreach (var result in Validate(item))
-                    {
-                        yield return result;
-                    }
-                }
-            }
-
-            var properties = TypeDescriptor.GetProperties(propertyType)
-                .Cast<PropertyDescriptor>()
-                .Where(p => !p.IsReadOnly);
-
-            foreach (var property in properties)
-            {
-                foreach (var result in ValidateProperties(property, value))
-                {
-                    yield return result;
-                }
-            }
-        }
+      foreach (var validationResult in GetValidationResults(value.GetType(), value)) {
+        yield return validationResult;
+      }
     }
+
+    /// <summary>
+    ///     Validates the properties.
+    /// </summary>
+    /// <param name="propertyDescriptor">The property descriptor.</param>
+    /// <param name="container">The container.</param>
+    /// <returns></returns>
+    private IEnumerable<ValidationResult> ValidateProperties(PropertyDescriptor propertyDescriptor, object container) {
+      var value = propertyDescriptor.GetValue(container);
+
+      var context = new ValidationContext(container, null, null) {
+        DisplayName = propertyDescriptor.DisplayName,
+        MemberName = propertyDescriptor.Name
+      };
+
+      foreach (var validationAttribute in propertyDescriptor.Attributes.OfType<ValidationAttribute>()) {
+        var result = validationAttribute.GetValidationResult(value, context);
+
+        if (result != ValidationResult.Success) {
+          yield return result;
+        }
+      }
+
+      if (value != null) {
+        foreach (var validationResult in GetValidationResults(propertyDescriptor.PropertyType, value)) {
+          yield return validationResult;
+        }
+      }
+    }
+
+    /// <summary>
+    ///     Gets the validation results.
+    /// </summary>
+    /// <param name="propertyType">Type of the property.</param>
+    /// <param name="value">The value.</param>
+    /// <returns></returns>
+    private IEnumerable<ValidationResult> GetValidationResults(Type propertyType, object value) {
+      if (value is IEnumerable enumerable) {
+        foreach (var item in enumerable) {
+          foreach (var result in Validate(item)) {
+            yield return result;
+          }
+        }
+      }
+
+      var context = new ValidationContext(value, null, null) {
+        DisplayName = propertyType.Name,
+        MemberName = propertyType.Name
+      };
+
+      foreach (var validationAttibute in propertyType.GetCustomAttributes<ValidationAttribute>()) {
+        var result = validationAttibute.GetValidationResult(value, context);
+
+        if (result != ValidationResult.Success) {
+          yield return result;
+        }
+      }
+
+      var properties = TypeDescriptor.GetProperties(propertyType)
+          .Cast<PropertyDescriptor>()
+          .Where(p => !p.IsReadOnly);
+
+      foreach (var property in properties) {
+        foreach (var result in ValidateProperties(property, value)) {
+          yield return result;
+        }
+      }
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations/ErrorMessageGenerator.cs
+++ b/DevTrends.WCFDataAnnotations/ErrorMessageGenerator.cs
@@ -4,59 +4,52 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Default error message generation that uses the error messages from the 
+  /// <see cref="IEnumerable{ValidationResult}"/>
+  /// </summary>
+  public class ErrorMessageGenerator : IErrorMessageGenerator {
     /// <summary>
-    /// Default error message generation that uses the error messages from the 
-    /// <see cref="IEnumerable{ValidationResult}"/>
+    /// Generates the error message.
     /// </summary>
-    public class ErrorMessageGenerator : IErrorMessageGenerator
-    {
-        /// <summary>
-        /// Generates the error message.
-        /// </summary>
-        /// <param name="operationName">Name of the operation.</param>
-        /// <param name="validationResults">The validation results.</param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// operationName
-        /// or
-        /// validationResults
-        /// </exception>
-        /// <exception cref="System.ArgumentException">At least one ValidationResult is required</exception>
-        public string GenerateErrorMessage(string operationName, IEnumerable<ValidationResult> validationResults)
-        {
-            if (operationName == null)
-            {
-                throw new ArgumentNullException("operationName");
-            }
+    /// <param name="operationName">Name of the operation.</param>
+    /// <param name="validationResults">The validation results.</param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// operationName
+    /// or
+    /// validationResults
+    /// </exception>
+    /// <exception cref="System.ArgumentException">At least one ValidationResult is required</exception>
+    public string GenerateErrorMessage(string operationName, IEnumerable<ValidationResult> validationResults) {
+      if (operationName == null) {
+        throw new ArgumentNullException(nameof(operationName));
+      }
 
-            if (validationResults == null)
-            {
-                throw new ArgumentNullException("validationResults");
-            }
+      if (validationResults == null) {
+        throw new ArgumentNullException(nameof(validationResults));
+      }
 
-            if (!validationResults.Any())
-            {
-                throw new ArgumentException("At least one ValidationResult is required");
-            }
+      if (!validationResults.Any()) {
+        throw new ArgumentException("At least one ValidationResult is required");
+      }
 
-            var errorMessageBuilder = new StringBuilder();
+      var errorMessageBuilder = new StringBuilder();
 
-            errorMessageBuilder.AppendFormat(
-                "Service operation {0} failed due to validation errors: {1}{1}",
-                operationName,
-                Environment.NewLine);
+      errorMessageBuilder.AppendFormat(
+          "Service operation {0} failed due to validation errors: {1}{1}",
+          operationName,
+          Environment.NewLine);
 
-            foreach (var validationResult in validationResults)
-            {
-                errorMessageBuilder.AppendFormat(
-                    "{0} {1}",
-                    validationResult.ErrorMessage,
-                    Environment.NewLine);
-            }
+      foreach (var validationResult in validationResults) {
+        errorMessageBuilder.AppendFormat(
+            "{0} {1}",
+            validationResult.ErrorMessage,
+            Environment.NewLine);
+      }
 
-            return errorMessageBuilder.ToString();
-        }
+      return errorMessageBuilder.ToString();
     }
+  }
 }

--- a/DevTrends.WCFDataAnnotations/IErrorMessageGenerator.cs
+++ b/DevTrends.WCFDataAnnotations/IErrorMessageGenerator.cs
@@ -1,19 +1,17 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Generates an error message for an operation based on the validation results
+  /// </summary>
+  public interface IErrorMessageGenerator {
     /// <summary>
-    /// Generates an error message for an operation based on the validation results
+    /// Generates the error message.
     /// </summary>
-    public interface IErrorMessageGenerator
-    {
-        /// <summary>
-        /// Generates the error message.
-        /// </summary>
-        /// <param name="operationName">Name of the operation.</param>
-        /// <param name="validationResults">The validation results.</param>
-        /// <returns></returns>
-        string GenerateErrorMessage(string operationName, IEnumerable<ValidationResult> validationResults);
-    }
+    /// <param name="operationName">Name of the operation.</param>
+    /// <param name="validationResults">The validation results.</param>
+    /// <returns></returns>
+    string GenerateErrorMessage(string operationName, IEnumerable<ValidationResult> validationResults);
+  }
 }

--- a/DevTrends.WCFDataAnnotations/IObjectValidator.cs
+++ b/DevTrends.WCFDataAnnotations/IObjectValidator.cs
@@ -1,21 +1,19 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Validates an object
+  /// </summary>
+  public interface IObjectValidator {
     /// <summary>
-    /// Validates an object
+    ///     Validates the object.
     /// </summary>
-    public interface IObjectValidator
-    {
-        /// <summary>
-        ///     Validates the object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <returns>
-        ///     A collection of <see cref="ValidationResult" /> containing information
-        ///     about validation errors
-        /// </returns>
-        IEnumerable<ValidationResult> Validate(object value);
-    }
+    /// <param name="value">The object to validate.</param>
+    /// <returns>
+    ///     A collection of <see cref="ValidationResult" /> containing information
+    ///     about validation errors
+    /// </returns>
+    IEnumerable<ValidationResult> Validate(object value);
+  }
 }

--- a/DevTrends.WCFDataAnnotations/NullCheckObjectValidator.cs
+++ b/DevTrends.WCFDataAnnotations/NullCheckObjectValidator.cs
@@ -1,27 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Validates objects to ensure they are not null
+  /// </summary>
+  public class NullCheckObjectValidator : IObjectValidator {
     /// <summary>
-    /// Validates objects to ensure they are not null
+    /// Validates the object.
     /// </summary>
-    public class NullCheckObjectValidator : IObjectValidator
-    {
-        /// <summary>
-        /// Validates the object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <returns>
-        /// A collection of <see cref="ValidationResult" /> containing information
-        /// about validation errors
-        /// </returns>
-        public IEnumerable<ValidationResult> Validate(object value)
-        {
-            if (value == null)
-            {
-                yield return new ValidationResult("Input is null.");                
-            }            
-        }
+    /// <param name="value">The object to validate.</param>
+    /// <returns>
+    /// A collection of <see cref="ValidationResult" /> containing information
+    /// about validation errors
+    /// </returns>
+    public IEnumerable<ValidationResult> Validate(object value) {
+      if (value == null) {
+        yield return new ValidationResult("Input is null.");
+      }
     }
+  }
 }

--- a/DevTrends.WCFDataAnnotations/ValidatableObjectValidator.cs
+++ b/DevTrends.WCFDataAnnotations/ValidatableObjectValidator.cs
@@ -1,34 +1,71 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Validates objects that implement <see cref="IValidatableObject"/>
+  /// </summary>
+  public class ValidatableObjectValidator : IObjectValidator {
     /// <summary>
-    /// Validates objects that implement <see cref="IValidatableObject"/>
+    /// Validates the object.
     /// </summary>
-    public class ValidatableObjectValidator : IObjectValidator
-    {
-        /// <summary>
-        /// Validates the object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <returns>
-        /// A collection of <see cref="ValidationResult" /> containing information
-        /// about validation errors
-        /// </returns>
-        public IEnumerable<ValidationResult> Validate(object value)
-        {
-            var validatableInput = value as IValidatableObject;
+    /// <param name="value">The object to validate.</param>
+    /// <returns>
+    /// A collection of <see cref="ValidationResult" /> containing information
+    /// about validation errors
+    /// </returns>
+    public IEnumerable<ValidationResult> Validate(object value) {
+      if (value == null) {
+        yield break;
+      }
 
-            if (validatableInput != null)
-            {
-                var context = new ValidationContext(value, null, null);
+      if (value is IValidatableObject validatableInput) {
+        var context = new ValidationContext(value, null, null);
 
-                foreach (var result in validatableInput.Validate(context))
-                {
-                    yield return result;
-                }
-            }
+        foreach (var result in validatableInput.Validate(context)) {
+          yield return result;
         }
+      }
+
+      if (value is IEnumerable enumerable) {
+        var validationResults = ValidateEnumerable(enumerable);
+        foreach (var validationResult in validationResults) {
+          yield return validationResult;
+        }
+      }
+
+      var properties = TypeDescriptor.GetProperties(value.GetType())
+        .Cast<PropertyDescriptor>()
+        .Where(p => !p.IsReadOnly);
+
+      foreach (var property in properties) {
+        foreach (var result in Validate(property.GetValue(value))) {
+          yield return result;
+        }
+      }
     }
+
+    /// <summary>
+    /// Rescursively validate enumerables
+    /// </summary>
+    /// <param name="enumerable"></param>
+    /// <returns>If validation fails, it returns the validation results</returns>
+    private IEnumerable<ValidationResult> ValidateEnumerable(IEnumerable enumerable) {
+      foreach (var item in enumerable) {
+        if (item is IEnumerable nestedEnumerable) {
+          var nestedValidationResults = ValidateEnumerable(nestedEnumerable);
+          foreach (var nestedValidationResult in nestedValidationResults) {
+            yield return nestedValidationResult;
+          }
+        }
+
+        foreach (var result in Validate(item)) {
+          yield return result;
+        }
+      }
+    }
+  }
 }

--- a/DevTrends.WCFDataAnnotations/ValidateDataAnnotationsBehavior.cs
+++ b/DevTrends.WCFDataAnnotations/ValidateDataAnnotationsBehavior.cs
@@ -67,7 +67,7 @@ namespace DevTrends.WCFDataAnnotations {
         select operation;
 
       var contractOperations = serviceHostBase.Description.Endpoints.SelectMany(x => x.Contract.Operations).ToList();
-      
+
       foreach (var operation in operations) {
         var parameterInfo = GetParameterInfo(operation.Name, contractOperations);
 
@@ -93,7 +93,7 @@ namespace DevTrends.WCFDataAnnotations {
     /// <returns></returns>
     private ParameterDetailsInfo GetParameterInfo(string operationName, IEnumerable<OperationDescription> contractOperations) {
       var parameterInfo = new ParameterDetailsInfo();
-      
+
       var parameters = GetParameters(contractOperations.Single(x => x.Name == operationName));
 
       foreach (var parameter in parameters.OrderBy(x => x.Position)) {
@@ -117,7 +117,7 @@ namespace DevTrends.WCFDataAnnotations {
       if (method == null) {
         throw new InvalidOperationException("Either SyncMethod or TaskMethod should have a value!");
       }
-      
+
       return method.GetParameters();
     }
   }

--- a/DevTrends.WCFDataAnnotations/ValidateDataAnnotationsBehaviorExtensionElement.cs
+++ b/DevTrends.WCFDataAnnotations/ValidateDataAnnotationsBehaviorExtensionElement.cs
@@ -1,31 +1,25 @@
 ﻿using System;
 using System.ServiceModel.Configuration;
 
-namespace DevTrends.WCFDataAnnotations
-{
+namespace DevTrends.WCFDataAnnotations {
+  /// <summary>
+  /// Extension for creating a <see cref="ValidateDataAnnotationsBehavior"/> through
+  /// configuration
+  /// </summary>
+  public class ValidateDataAnnotationsBehaviorExtensionElement : BehaviorExtensionElement {
     /// <summary>
-    /// Extension for creating a <see cref="ValidateDataAnnotationsBehavior"/> through
-    /// configuration
+    /// Gets the type of behavior.
     /// </summary>
-    public class ValidateDataAnnotationsBehaviorExtensionElement : BehaviorExtensionElement
-    {
-        /// <summary>
-        /// Gets the type of behavior.
-        /// </summary>
-        public override Type BehaviorType
-        {
-            get { return typeof(ValidateDataAnnotationsBehavior); }
-        }
+    public override Type BehaviorType => typeof(ValidateDataAnnotationsBehavior);
 
-        /// <summary>
-        /// Creates a behavior extension based on the current configuration settings.
-        /// </summary>
-        /// <returns>
-        /// The behavior extension.
-        /// </returns>
-        protected override object CreateBehavior()
-        {
-            return new ValidateDataAnnotationsBehavior();
-        }
+    /// <summary>
+    /// Creates a behavior extension based on the current configuration settings.
+    /// </summary>
+    /// <returns>
+    /// The behavior extension.
+    /// </returns>
+    protected override object CreateBehavior() {
+      return new ValidateDataAnnotationsBehavior();
     }
+  }
 }

--- a/DevTrends.WCFDataAnnotations/ValidatingParameterInspector.cs
+++ b/DevTrends.WCFDataAnnotations/ValidatingParameterInspector.cs
@@ -23,7 +23,7 @@ namespace DevTrends.WCFDataAnnotations {
     /// <param name="parameterDetailsInfo">The parameter info object for the optional validator skipping.</param>
     public ValidatingParameterInspector(IEnumerable<IObjectValidator> validators, IErrorMessageGenerator errorMessageGenerator, ParameterDetailsInfo parameterDetailsInfo = null) {
       if (validators == null) {
-        throw new ArgumentNullException("validators");
+        throw new ArgumentNullException(nameof(validators));
       }
 
       if (!validators.Any()) {
@@ -31,7 +31,7 @@ namespace DevTrends.WCFDataAnnotations {
       }
 
       if (errorMessageGenerator == null) {
-        throw new ArgumentNullException("errorMessageGenerator");
+        throw new ArgumentNullException(nameof(errorMessageGenerator));
       }
 
       _validators = validators;
@@ -48,8 +48,7 @@ namespace DevTrends.WCFDataAnnotations {
     /// <param name="correlationState">Any correlation state returned from the 
     /// <see cref="M:System.ServiceModel.Dispatcher.IParameterInspector.BeforeCall(System.String,System.Object[])" /> method, 
     /// or null.</param>
-    public void AfterCall(string operationName, object[] outputs, object returnValue, object correlationState) {
-    }
+    public void AfterCall(string operationName, object[] outputs, object returnValue, object correlationState) { }
 
     /// <summary>
     /// Called before client calls are sent and after service responses are returned.
@@ -80,10 +79,10 @@ namespace DevTrends.WCFDataAnnotations {
 
       return null;
     }
-    
+
     private IEnumerable<IObjectValidator> GetValidators(int parameterPosition) {
-      return _parameterDetailsInfo != null && _parameterDetailsInfo.ParameterDetails.Single(x => x.Position == parameterPosition).SkipNullcheck 
-        ? _validators.Where(x => !(x is NullCheckObjectValidator)) 
+      return _parameterDetailsInfo != null && _parameterDetailsInfo.ParameterDetails.Single(x => x.Position == parameterPosition).SkipNullcheck
+        ? _validators.Where(x => !(x is NullCheckObjectValidator))
         : _validators;
     }
   }


### PR DESCRIPTION
With the original implementation there are cases when the validation doesn't getting fired. 
One case when the object you want to validate has enumerables or nested enumerables, or for the ValidatableObject if it is a property, or you are using custom validation attributes etc. 

In our in-house implementation we fixed those issues already, so now I am merging that into this fork too.

Some extra steps were also done:
1. Reformatted the code according to our style guide
2. Implemented recursive validation for Enumerables and nested enumerables
3. Extended unit tests for covering the new functionalities