### PR TITLE
Fix activation of validation behavior when multiple endpoints are declared

### DIFF
--- a/Independer.WCFDataAnnotations/Independer.WCFDataAnnotations.csproj
+++ b/Independer.WCFDataAnnotations/Independer.WCFDataAnnotations.csproj
@@ -5,7 +5,7 @@
 		<Authors>Independer</Authors>
 		<Description>Extended and improved version of the original DevTrends.WCFDataAnnotations library. WCFDataAnnotations allows you to automatically validate WCF service operation arguments using the validation attributes and IValidatableObject interface from System.ComponentModel.DataAnnotations.</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<VersionPrefix>1.3.0</VersionPrefix>
+		<VersionPrefix>1.3.1</VersionPrefix>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/Independer/wcfdataannotations</PackageProjectUrl>
 		<PackageReleaseNotes>The improved WCF Data Annotations. Validate Data Annotations Validation Attributes applied to properties down the entire object graph</PackageReleaseNotes>

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ If you used that package previously, you can migrate and continue using the main
 
 ## Version history
 
+ * 1.3.1
+   * Bug fixes:
+     * Fixed an issue with activating validation behavior when multiple service endpoints are declared  
  * 1.3.0 
    * Enhancements:
      * Package is now signed


### PR DESCRIPTION
The fix affects ValidateDataAnnotationsBehavior for multiple service endpoints.

When multiple service endpoints are declared, current logic filters out discovered dispatched operations in a way that only the first declared endpoint gets validation activated correctly.

This change fixes the filtering so for all endpoints and gets rid of a few IEnumerable-related warnings.